### PR TITLE
fix : body padding issue

### DIFF
--- a/inc/extensions/header.php
+++ b/inc/extensions/header.php
@@ -150,7 +150,7 @@ function header_sticky_inline_js( string $js ): string {
 		const body = document.querySelector( 'body' );
 		if( header ) {
 
-			const height = header.offsetHeight;
+			const height = header.getBoundingClientRect().height;
 
 			if( height ) {
 				body.style.paddingTop = parseFloat( height ) + 'px';


### PR DESCRIPTION
### Description
Resolve the sub-pixel rendering issue that was causing a visible white gap between the sticky header and the next element on the page in certain screen sizes and resolutions.

Previously, the function stickyHeaderSpacing used offsetHeight to get the header's height. This method rounds the value to the nearest integer. So if the actual height was 30.5px, offsetHeight would round it up to 31px. This rounding caused a 0.5px gap in some cases, which led to a visible white line between the elements.

The change is made to use getBoundingClientRect().height instead, which retains the sub-pixel value. For example, if the height is 30.5px, the body will now have a padding-top of 30.5px instead of 31px, effectively eliminating the gap.

### Types of changes
Bug fix

### How has this been tested?
The fix has been tested on Google Chrome, Firefox, and Microsoft Edge on desktop. During the tests, the following lines was used to simulate a header with a height that includes a half-pixel value:
`const header = document.querySelector( '.swt-sticky-header' );`
`header.querySelector('div.has-background').style.height= Math.floor(parseFloat(header.offsetHeight))+0.5 + 'px';`

Checklist:
- [X] My code is tested
- [ ] My code passes the PHPCS tests
- [ ] My code follows accessibility standards
- [ ] My code has proper inline documentation
- [ ] I've included any necessary tests
- [ ] I've included developer documentation
- [ ] I've added proper labels to this pull request
