### PR TITLE
SPEC-270 - Editor styling not loading on page and post

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -106,16 +106,10 @@ function enqueue_editor_scripts(): void {
 	$settings_deps  = $settings_asset['dependencies'];
 	array_push( $settings_deps, 'updates' );
 
+	// Enqueue editor styles for post and page.
+	wp_enqueue_style( SWT_SLUG . '-editor-css', $css_uri . 'editor' . $file_prefix . '.css', array(), SWT_VER );
+
 	wp_enqueue_style( SWT_SLUG . '-gutenberg-editor', $css_uri . 'gutenberg-editor' . $file_prefix . '.css', array(), SWT_VER );
-
-	// Enqueue editor styles.
-	/** @psalm-suppress UndefinedFunction */ // phpcs:ignore PossiblyFalseArgument, Generic.Commenting.DocComment.MissingShort -- Function exist in helpers.php
-	if ( wp_version_compare( '6.2.99', '<=' ) ) {
-		add_editor_style( $css_uri . 'compatibility/duotone' . $file_prefix . '.css' );
-	}
-
-	// Load in pages and post editor.
-	add_editor_style( $css_uri . 'editor' . $file_prefix . '.css' );
 
 	wp_register_script( SWT_SLUG . '-editor', $js . 'editor.js', $deps, SWT_VER, true );
 


### PR DESCRIPTION
### Description
Jira : https://brainstormforce.atlassian.net/browse/SPEC-270

### Screenshots
https://d.pr/i/cBnn89

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Checked in page and post with old and new wp version if issue still exist 

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
